### PR TITLE
Update 09-run-multiple-parallel-traders.Rmd

### DIFF
--- a/09-run-multiple-parallel-traders.Rmd
+++ b/09-run-multiple-parallel-traders.Rmd
@@ -365,6 +365,7 @@ iex(1)> :observer.start()
 iex(2)> Naive.start_trading("HNTUSDT")
 10:22:05.018 [info]  The trader(1616754009963) is placing a BUY order for HNTUSDT @ 8.175,
 quantity: 2.446
+iex(3)> Streamer.start_streaming("HNTUSDT")
 10:22:11.665 [info]  Rebuy triggered for HNTUSDT by the trader(1616754009963)
 10:22:11.665 [info]  Starting new trader for HNTUSDT
 10:22:11.665 [info]  Initializing new trader(1616754131665) for HNTUSDT


### PR DESCRIPTION
While following the book step-by-step, I got stuck at this point for two hours and finally realized it was because the line  

```elixir
Streamer.start_streaming("XXXUSDT")
```  

was missing—so that part needs to be fixed.

Also, the `:observer.start()` command can’t be used directly in the latest IEx anymore; you have to add the following to `mix.exs`:

```elixir
def application do
  [
    extra_applications: [:logger, :observer, :wx, :runtime_tools]
  ]
end
```

There’s an alternative, though:

```iex
Mix.ensure_application!(:observer)
:observer.start()
```